### PR TITLE
--days should be moved from the install task to the issue task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
   args:
     chdir: "~/.acme.sh"
   when:
-    - acme_sh_upgrade
+    - acme_sh_upgrade|bool
     - is_acme_sh_installed.stat.exists
     - not acme_sh_uninstall
   register: upgrade_result
@@ -68,7 +68,7 @@
   args:
     chdir: "~/.acme.sh"
   when:
-    - acme_sh_uninstall
+    - acme_sh_uninstall|bool
     - is_acme_sh_installed.stat.exists
   become_user: "{{ acme_sh_become_user }}"
 
@@ -116,7 +116,7 @@
     - "{{ acme_sh_git_clone_dest }}"
     - "~/.acme.sh"
   when:
-    - acme_sh_uninstall
+    - acme_sh_uninstall|bool
   become_user: "{{ acme_sh_become_user }}"
 
 - name: Run custom acme.sh command

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,6 @@
 - name: Install acme.sh
   command: >-
     ./acme.sh --install --log
-    --days {{ acme_sh_renew_time_in_days }}
     {{ "--accountemail " + acme_sh_account_email if acme_sh_account_email else "" }}
   args:
     chdir: "{{ acme_sh_git_clone_dest }}"
@@ -109,7 +108,7 @@
     - item.remove is defined and item.remove
     - not acme_sh_uninstall
 
-- name: Remove acme.sh's cloned source code, installation path and log files
+- name: Remove the acme.sh cloned source code, installation path and log files
   file:
     path: "{{ item }}"
     state: "absent"
@@ -140,6 +139,7 @@
     ./acme.sh --issue -d {{ item.domains | join(" -d ") }}
     --dns {{ item.dns_provider | default(acme_sh_default_dns_provider) }}
     --dnssleep {{ item.dns_sleep | default(acme_sh_default_dns_sleep) }}
+    --days {{ acme_sh_renew_time_in_days }}
     {{ "--force" if item.force_issue | default(acme_sh_default_force_issue) else "" }}
     {{ "--staging" if item.staging | default(acme_sh_default_staging) else "" }}
     {{ "--debug" if item.debug | default(acme_sh_default_debug) else "" }}


### PR DESCRIPTION
The renewal days value was used in the install (install of acme.sh itself) task. But acme.sh does not use the --days argument. However, the acme.sh issue task does use the --days argument. So, move the --days argument from the install task to the issue task.

The renew task also appears to use the --days argument. But, I was not able to verify that it would be appropriate to use the --days argument in the renew task as well.

Added |bool to avoid deprecation warnings where a bare var was used as a boolean.