### PR TITLE
allow specifying dependencies packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ webroot, nginx or Apache but nothing is set in stone.
 # needs to already exist, this role will not create it.
 acme_sh_become_user: "root"
 
+# acme.sh package dependencies. The default values are for Debian / Ubuntu.
+# For CentOS and Fedora you can replace "cron" with "crond".
+acme_sh_dependencies: ["cron", "git", "wget"]
+
 # The acme.sh repo to clone.
 acme_sh_git_url: "https://github.com/Neilpang/acme.sh"
 
@@ -275,9 +279,6 @@ acme_sh_domains:
 #    extra_issue_renew_hook: ""
 #    # Optionally remove and disable the certificate.
 #    remove: True
-
-# How long should the apt-cache last in seconds?
-acme_sh_apt_cache_time: 86400
 ```
 
 ## Example usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 acme_sh_become_user: "root"
 
+acme_sh_dependencies: ["cron", "git", "wget"]
+
 acme_sh_git_url: "https://github.com/Neilpang/acme.sh"
 acme_sh_git_version: "master"
 acme_sh_git_update: False
@@ -42,5 +44,3 @@ acme_sh_default_issue_renew_hook: ""
 acme_sh_default_remove: False
 
 acme_sh_domains: []
-
-acme_sh_apt_cache_time: 86400

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 
 - name: Install dependencies
-  apt:
+  package:
     name: "{{ item }}"
-    update_cache: True
-    cache_valid_time: "{{ acme_sh_apt_cache_time }}"
-  loop: ["cron", "git", "wget"]
+    state: "present"
+  loop: "{{ acme_sh_dependencies }}"
   when: not acme_sh_uninstall
 
 - name: Create git clone path

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,6 +14,11 @@
         name: "{{ acme_sh_become_user }}"
         shell: "/bin/bash"
 
+    - name: Run the equivalent of "apt-get update"
+      apt:
+        update_cache: true
+      changed_when: false
+
   post_tasks:
     - name: Ensure acme.sh was cloned
       command: test -d /usr/local/src/acme.sh


### PR DESCRIPTION
This allows to install on CentOS, Fedora and other OSes by specifying
the packages manually.
Example:
Fedora packages would be `crond`, `git` and `wget`.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

One potential issue might be the switch to use `package:` module instead of `apt` though that could be altered to use `apt:` module when the package manager is `apt` on the system. For other OSes where the cache(s) are automatically refreshed the `package:` could be used.
What do you think?