### PR TITLE
Don't try to list certificate information when on ansible check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -229,4 +229,4 @@
 - name: List acme.sh certificate information
   debug:
     msg: "{{ list_domains.stdout_lines }}"
-  when: acme_sh_list_domains and not acme_sh_uninstall
+  when: not ansible_check_mode and acme_sh_list_domains and not acme_sh_uninstall


### PR DESCRIPTION
In check mode ansible does not execute shell scripts, so there are no certificate information to show.

Fixes #7 